### PR TITLE
Fixed sql and sh scripts

### DIFF
--- a/scripts/pay_sys_dump.sql
+++ b/scripts/pay_sys_dump.sql
@@ -19,7 +19,7 @@ DROP DATABASE IF EXISTS payment_system;
 -- Name: payment_system; Type: DATABASE; Schema: -; Owner: postgres
 --
 
-CREATE DATABASE payment_system WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
+CREATE DATABASE payment_system WITH TEMPLATE = template0;
 
 
 ALTER DATABASE payment_system OWNER TO postgres;

--- a/scripts/restore_pay_sys.sh
+++ b/scripts/restore_pay_sys.sh
@@ -3,14 +3,29 @@ path_to_sql="./pay_sys_dump.sql"
 if (( $# < 1 )); then
     echo "Default path is current directory."
     echo "You can pass the path to the *.sql script to restore database"
-    echo "./restore_pay_sys.sh /some/path/to/script"
+    echo "./restore_pay_sys.sh /some/path/to/script [linux | mac]"
     echo ""
 else
     path_to_sql="$1/pay_sys_dump.sql"
 fi
-    
 echo $path_to_sql
 
-restore_cmd="psql -f $path_to_sql 2>&1 >/dev/null && echo 'Database payment_system recovery completed successfully!' || echo 'Database payment_system recovery failed!'"
+os_type="linux"
+if (( $# == 2 )); then
+    echo "Choosed $2 system"
+    os_type=$2
+else
+    echo "Choosed default system (linux)"
+fi
 
-sudo su postgres -c "$restore_cmd"
+if [[ $os_type == "mac" ]]; then
+    psql -f $path_to_sql 2>&1 >/dev/null \
+        && echo 'Database payment_system recovery completed successfully!' \
+        || echo 'Database payment_system recovery failed!'
+else 
+    restore_cmd="psql -f $path_to_sql 2>&1 >/dev/null \
+    && echo 'Database payment_system recovery completed successfully!' \
+    || echo 'Database payment_system recovery failed!'"
+
+    sudo su postgres -c "$restore_cmd"
+fi


### PR DESCRIPTION
1) Removed info about locales and encoding from CREATE DATABASE command in sql script (that's work in any system (approved)).
2) Extended shell script for restoring database:
 - In Linux you can omit any parameters
 - In MacOS you need to specify arguments, in example "./restore_pay_sys.sh ./ mac".
3) For restoring database in Windows you still need to manually pass script throught psql:
cd <path\to\postgres>\bin
psql -U postgres -f <path\to\sql_script>\pay_sys_dump.sql